### PR TITLE
Improve exception handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ python:
   - 3.2
   - 3.3
 install:
-  - pip install --use-mirrors --upgrade pytest>=2.4
-  - pip install --use-mirrors --upgrade filesystem_tree
+  - pip install --upgrade filesystem_tree pytest>=2.4
   - pip install ./
-script: 
+script:
   - ./runtests.sh
 notifications:
   email: false

--- a/algorithm.py
+++ b/algorithm.py
@@ -296,8 +296,7 @@ class Algorithm(object):
                                     sys.exc_clear()
                         state.update(new_state)
             except:
-                ExceptionClass, exception = sys.exc_info()[:2]
-                state['exception'] = exception
+                state['exception'] = sys.exc_info()[1]
                 if _raise_immediately:
                     raise
 

--- a/algorithm.py
+++ b/algorithm.py
@@ -296,6 +296,7 @@ class Algorithm(object):
                             return function
                 except:
                     handle_exception()
+            raise  # exception hasn't been handled, reraise
 
         for function in functions_iter:
             try:
@@ -313,25 +314,6 @@ class Algorithm(object):
             if _return_after is not None:
                 if function.__name__ == _return_after:
                     break
-
-        if state['exception'] is not None:
-            if PYTHON_2:
-
-                # Under Python 2, raising state['exception'] means the
-                # traceback stops at this reraise. We want the traceback to go
-                # back to where the exception was first raised, and a naked
-                # raise will reraise the current exception.
-
-                raise
-
-            else:
-
-                # Under Python 3, exceptions are cleared at the end of the
-                # except block, meaning we have no current exception to reraise
-                # here. Thankfully, the traceback off this reraise will show
-                # back to the original exception.
-
-                raise state['exception']
 
         return state
 

--- a/algorithm.py
+++ b/algorithm.py
@@ -279,7 +279,6 @@ class Algorithm(object):
         if 'exception' not in state:    state['exception'] = None
 
         for function in self.functions:
-            function_name = function.__name__
             try:
                 deps = resolve_dependencies(function, state)
                 have_exception = state['exception'] is not None
@@ -300,8 +299,9 @@ class Algorithm(object):
                     raise
                 state['exception'] = sys.exc_info()[1]
 
-            if _return_after is not None and function_name == _return_after:
-                break
+            if _return_after is not None:
+                if function.__name__ == _return_after:
+                    break
 
         if state['exception'] is not None:
             if PYTHON_2:

--- a/algorithm.py
+++ b/algorithm.py
@@ -296,9 +296,9 @@ class Algorithm(object):
                                     sys.exc_clear()
                         state.update(new_state)
             except:
-                state['exception'] = sys.exc_info()[1]
                 if _raise_immediately:
                     raise
+                state['exception'] = sys.exc_info()[1]
 
             if _return_after is not None and function_name == _return_after:
                 break

--- a/tests.py
+++ b/tests.py
@@ -132,9 +132,19 @@ def test_exception_fast_forwards(sys_path):
     state = foo_algorithm.run()
     assert state == {'val': 666, 'exception': None, 'state': state, 'algorithm': foo_algorithm}
 
+def assert_false():
+    assert False
+
+def clear_exception(state, exception):
+    state['exception'] = None
+
+def dont_call_me(exception):
+    raise Exception("I said don't call me!")
+
+def test_exception_handlers_are_skipped_when_there_is_no_exception(sys_path):
+    Algorithm(dont_call_me, assert_false, clear_exception, dont_call_me).run()
+
 def test_exc_info_is_available_during_exception_handling(sys_path):
-    def assert_false():
-        assert False
     def check_exc_info(exception):
         assert sys.exc_info()[1] is exception
         return {'exception': None}

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,7 @@ import sys
 
 import traceback
 from pytest import raises, yield_fixture
-from algorithm import Algorithm, FunctionNotFound, PYTHON_2
+from algorithm import Algorithm, FunctionNotFound
 from filesystem_tree import FilesystemTree
 
 
@@ -154,11 +154,10 @@ def test_traceback_for_uncleared_exception_reaches_back_to_original_raise(sys_pa
         foo_algorithm.run()
     except:
         tb = traceback.format_exc()
-
-    # We get an extra frame under Python 3, but what we don't want is not
-    # enough frames.
-
-    assert len(tb.splitlines()) == (8 if PYTHON_2 else 10)
+    lines = tb.splitlines()
+    assert lines[-1][:11] == 'NameError: '
+    assert "'heck'" in lines[-1]
+    assert len(lines) == 10
 
 def test_function_can_have_default_value_for_exception_to_be_always_called(sys_path):
     sys_path.mk(EXCEPT)

--- a/tests.py
+++ b/tests.py
@@ -167,7 +167,7 @@ def test_traceback_for_uncleared_exception_reaches_back_to_original_raise(sys_pa
     lines = tb.splitlines()
     assert lines[-1][:11] == 'NameError: '
     assert "'heck'" in lines[-1]
-    assert len(lines) == 10
+    assert len(lines) == 12, tb
 
 def test_function_can_have_default_value_for_exception_to_be_always_called(sys_path):
     sys_path.mk(EXCEPT)

--- a/tests.py
+++ b/tests.py
@@ -132,6 +132,14 @@ def test_exception_fast_forwards(sys_path):
     state = foo_algorithm.run()
     assert state == {'val': 666, 'exception': None, 'state': state, 'algorithm': foo_algorithm}
 
+def test_exc_info_is_available_during_exception_handling(sys_path):
+    def assert_false():
+        assert False
+    def check_exc_info(exception):
+        assert sys.exc_info()[1] is exception
+        return {'exception': None}
+    Algorithm(assert_false, check_exc_info).run()
+
 def test_exception_raises_if_uncleared(sys_path):
     sys_path.mk(EXCEPT)
     foo_algorithm = Algorithm.from_dotted_name('foo')


### PR DESCRIPTION
Currently the algorithm functions that handle exceptions aren't called from inside the `except` block, and since python3 clears `sys.exc_info` at the end of the `except` block, these functions don't have access to the traceback when running on python3.

This PR fixes that by moving exception handling inside the `except` block.